### PR TITLE
Fix Wav2Vec2 attention config mutation

### DIFF
--- a/src/audio_analysis/wav2vec2.py
+++ b/src/audio_analysis/wav2vec2.py
@@ -20,7 +20,8 @@ class Wav2Vec2Model(Wav2Vec2Model):
         output_hidden_states=None,
         return_dict=None,
     ):
-        self.config.output_attentions = True
+        if output_attentions is None:
+            output_attentions = True
 
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -84,7 +85,8 @@ class Wav2Vec2Model(Wav2Vec2Model):
         output_hidden_states=None,
         return_dict=None,
     ):
-        self.config.output_attentions = True
+        if output_attentions is None:
+            output_attentions = True
 
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states


### PR DESCRIPTION
## Summary
- avoid mutating `output_attentions` config in `Wav2Vec2Model`
- default to request attentions via function argument instead

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689b40bcea108332a9cd56f0e13b4d02